### PR TITLE
Add benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,16 @@ rand = "0.5"
 [dev-dependencies]
 sdl2 = "0.31.0"                         # SDL2 bindings for Rust
 cpal = "0.11.0"
+criterion = "0.3.1"
+
+[[bench]]
+name = "setup"
+harness = false
+
+[[bench]]
+name = "sample"
+harness = false
+
+[[bench]]
+name = "wave_type"
+harness = false

--- a/benches/sample.rs
+++ b/benches/sample.rs
@@ -1,0 +1,48 @@
+extern crate criterion;
+extern crate sfxr;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use sfxr::Sample;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Default samples
+
+    c.bench_function("pickup", |b| {
+        b.iter(|| {
+            black_box(Sample::pickup(None));
+        });
+    });
+    c.bench_function("laser", |b| {
+        b.iter(|| {
+            black_box(Sample::laser(None));
+        });
+    });
+    c.bench_function("explosion", |b| {
+        b.iter(|| {
+            black_box(Sample::explosion(None));
+        });
+    });
+    c.bench_function("powerup", |b| {
+        b.iter(|| {
+            black_box(Sample::powerup(None));
+        });
+    });
+    c.bench_function("hit", |b| {
+        b.iter(|| {
+            black_box(Sample::hit(None));
+        });
+    });
+    c.bench_function("jump", |b| {
+        b.iter(|| {
+            black_box(Sample::jump(None));
+        });
+    });
+    c.bench_function("blip", |b| {
+        b.iter(|| {
+            black_box(Sample::blip(None));
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/setup.rs
+++ b/benches/setup.rs
@@ -1,0 +1,41 @@
+extern crate criterion;
+extern crate sfxr;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use sfxr::{Generator, Sample, WaveType};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("setup without generate", |b| {
+        b.iter(|| {
+            let mut sample = Sample::new();
+            sample.wave_type = WaveType::Sine;
+            // Black box will make sure the compiler won't compile away the unused results
+            let _generator = black_box(Generator::new(sample));
+        });
+    });
+
+    c.bench_function("reset", |b| {
+        let mut buffer = [0.0; 44_100];
+
+        let mut sample = Sample::new();
+        sample.wave_type = WaveType::Sine;
+        let mut generator = Generator::new(sample);
+
+        generator.generate(&mut buffer);
+
+        b.iter(|| {
+            generator.reset();
+        });
+    });
+
+    c.bench_function("mutate", |b| {
+        let mut sample = Sample::new();
+
+        b.iter(|| {
+            sample.mutate(None);
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/wave_type.rs
+++ b/benches/wave_type.rs
@@ -1,0 +1,61 @@
+extern crate criterion;
+extern crate sfxr;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use sfxr::{Generator, Sample, WaveType};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Defaults with simple wave types
+
+    c.bench_function("sine wave", |b| {
+        let mut buffer = [0.0; 44_100];
+
+        let mut sample = Sample::new();
+        sample.wave_type = WaveType::Sine;
+        let mut generator = Generator::new(sample);
+
+        b.iter(|| {
+            generator.generate(&mut buffer);
+        });
+    });
+    c.bench_function("square wave", |b| {
+        let mut buffer = [0.0; 44_100];
+
+        let mut sample = Sample::new();
+        sample.wave_type = WaveType::Square;
+        let mut generator = Generator::new(sample);
+
+        b.iter(|| {
+            generator.generate(&mut buffer);
+        });
+    });
+    c.bench_function("triangle wave", |b| {
+        let mut buffer = [0.0; 44_100];
+
+        let mut sample = Sample::new();
+        sample.wave_type = WaveType::Triangle;
+        let mut generator = Generator::new(sample);
+
+        b.iter(|| {
+            generator.generate(&mut buffer);
+        });
+    });
+    c.bench_function("noise wave", |b| {
+        let mut buffer = [0.0; 44_100];
+
+        let mut sample = Sample::new();
+        sample.wave_type = WaveType::Noise;
+        let mut generator = Generator::new(sample);
+
+        b.iter(|| {
+            generator.generate(&mut buffer);
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = criterion_benchmark
+}
+criterion_main!(benches);


### PR DESCRIPTION
Can be run simply by running `cargo bench`. I'm adding this because I'm trying to see if I can get the performance of the library up to the point of where I'm able to use it as-is inside a game.